### PR TITLE
remove www prefix from domains

### DIFF
--- a/domains.txt
+++ b/domains.txt
@@ -1172,9 +1172,9 @@ wr.moeri.org
 wronghead.com
 wuzup.net
 wuzupmail.net
-www.e4ward.com
-www.gishpuppy.com
-www.mailinator.com
+e4ward.com
+gishpuppy.com
+mailinator.com
 wwwnew.eu
 xagloo.com
 xemaps.com


### PR DESCRIPTION
If the goal here is to allow folks to match an email domain to a known list disposable ones then we should not list their web addresses but, instead, their email ones. For instance bob@malinator.com would match malinator.com not www.malinator.com