### PR TITLE
Add brainonfire.net to whitelist

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -16,3 +16,4 @@ dr.com
 mindless.com
 i.ua
 com.ar
+brainonfire.net


### PR DESCRIPTION
#41 - Domain brainonfire.net is false positive.